### PR TITLE
Change plugin such that Jenkins sets the node online/offline state

### DIFF
--- a/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
+++ b/src/main/resources/hudson/plugins/ec2/AmazonEC2Cloud/config-entries.jelly
@@ -64,9 +64,6 @@ THE SOFTWARE.
     <f:entry title="${%Prevent Stop EC2 Instance Tag}" field="preventStopAwsTag">
       <f:textbox default="prevent_stop"/>
     </f:entry>
-    <f:entry title="${%Max minutes instance idle}" field="maxIdleMinutes">
-      <f:textbox default="15" />
-    </f:entry>
   </f:advanced>
   <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="region,useInstanceProfileForCredentials,credentialsId,privateKey,roleArn,roleSessionName" />
 </j:jelly>

--- a/src/test/java/hudson/plugins/ec2/InstanceStopTimerTest.java
+++ b/src/test/java/hudson/plugins/ec2/InstanceStopTimerTest.java
@@ -6,17 +6,26 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
+import antlr.ANTLRException;
 import hudson.model.Computer;
 import hudson.model.Executor;
+import hudson.model.Label;
 import hudson.model.Node;
+import hudson.model.Queue.Item;
+import hudson.model.Queue.Task;
+import hudson.model.labels.LabelAtom;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class InstanceStopTimerTest {
+
+    private static final String NODE_LABEL = "test_node";
 
     @Rule
     public JenkinsRule r = new JenkinsRule();
@@ -32,21 +41,28 @@ public class InstanceStopTimerTest {
     }
 
     @Test
-    public void testIdleNodeShouldBeStopped() throws IOException, InterruptedException {
+    public void testPendingShouldNotBeStopped() throws IOException, InterruptedException, ANTLRException {
         Computer computer = mock(Computer.class);
         when(computer.isConnecting()).thenReturn(false);
-        Executor executor = mock(Executor.class);
-        when(executor.isIdle()).thenReturn(true);
-        when(executor.getIdleStartMilliseconds()).thenReturn(0L);
-        when(computer.getAllExecutors()).thenReturn(Collections.singletonList(executor));
-        TestableStopTimer stopTimer = new TestableStopTimer(computer);
+        when(computer.isOffline()).thenReturn(true);
+        TestableStopTimer stopTimer = new TestableStopTimer(computer, false);
+        stopTimer.execute(null);
+        verify(testCloud, times(0)).stopNode(any());
+    }
+
+    @Test
+    public void testIdleNodeShouldBeStopped() throws IOException, InterruptedException, ANTLRException {
+        Computer computer = mock(Computer.class);
+        when(computer.isConnecting()).thenReturn(false);
+        when(computer.isOffline()).thenReturn(true);
+        TestableStopTimer stopTimer = new TestableStopTimer(computer, true);
         stopTimer.execute(null);
         verify(testCloud, times(1)).stopNode(any());
     }
 
     @Test
     public void testNoComputer() throws IOException, InterruptedException {
-        TestableStopTimer stopTimer = new TestableStopTimer(null);
+        TestableStopTimer stopTimer = new TestableStopTimer(null, false);
         stopTimer.execute(null);
         verify(testCloud, times(0)).stopNode(any());
     }
@@ -56,7 +72,7 @@ public class InstanceStopTimerTest {
         Computer computer = mock(Computer.class);
         when(computer.isConnecting()).thenReturn(true);
         when(computer.isOnline()).thenReturn(false);
-        TestableStopTimer stopTimer = new TestableStopTimer(computer);
+        TestableStopTimer stopTimer = new TestableStopTimer(computer, false);
         stopTimer.execute(null);
         verify(testCloud, times(0)).stopNode(any());
     }
@@ -69,7 +85,7 @@ public class InstanceStopTimerTest {
         when(executor.isIdle()).thenReturn(false);
         when(executor.getIdleStartMilliseconds()).thenReturn(System.currentTimeMillis());
         when(computer.getAllExecutors()).thenReturn(Collections.singletonList(executor));
-        TestableStopTimer stopTimer = new TestableStopTimer(computer);
+        TestableStopTimer stopTimer = new TestableStopTimer(computer, false);
         stopTimer.execute(null);
         verify(testCloud, times(0)).stopNode(any());
     }
@@ -77,27 +93,49 @@ public class InstanceStopTimerTest {
     private Node getNode() {
         Node node = mock(Node.class);
         when(node.getNodeName()).thenReturn("Test Node");
+        Set<LabelAtom> labelSet = new HashSet<>();
+        LabelAtom atom = new LabelAtom(NODE_LABEL);
+        labelSet.add(atom);
+        when(node.getAssignedLabels()).thenReturn(labelSet);
         return node;
     }
 
     private AmazonEC2Cloud getMockCloud() {
         AmazonEC2Cloud cloud = mock(AmazonEC2Cloud.class);
         when(cloud.isStartStopNodes()).thenReturn(true);
-        when(cloud.getMaxIdleMinutes()).thenReturn("2");
         when(cloud.isEc2Node(any())).thenReturn(true);
         return cloud;
     }
 
     private static class TestableStopTimer extends InstanceStopTimer {
         private Computer computer;
+        private boolean queueEmpty;
 
-        public TestableStopTimer(Computer testComputer) {
+        public TestableStopTimer(Computer testComputer, boolean queueEmpty) {
             computer = testComputer;
+            this.queueEmpty = queueEmpty;
         }
 
         @Override
         protected Computer getComputer(Node node) {
             return computer;
+        }
+
+        @Override
+        protected Item[] getItems() {
+            if (queueEmpty) {
+                return new Item[0];
+            }
+
+            Item[] items = new Item[1];
+            Item item = mock(Item.class);
+            try {
+                when(item.getAssignedLabel()).thenReturn(Label.parseExpression(NODE_LABEL));
+            } catch ( ANTLRException e ) {
+                e.printStackTrace();
+            }
+            items[0] = item;
+            return items;
         }
     }
 }

--- a/src/test/java/hudson/plugins/ec2/StartInstanceProvisionerStrategyTest.java
+++ b/src/test/java/hudson/plugins/ec2/StartInstanceProvisionerStrategyTest.java
@@ -74,7 +74,6 @@ public class StartInstanceProvisionerStrategyTest {
     private AmazonEC2Cloud getMockCloud() {
         AmazonEC2Cloud cloud = mock(AmazonEC2Cloud.class);
         when(cloud.isStartStopNodes()).thenReturn(true);
-        when(cloud.getMaxIdleMinutes()).thenReturn("2");
         when(cloud.isEc2Node(any())).thenReturn(true);
         return cloud;
     }


### PR DESCRIPTION
Update the plugin to let Jenkins control Node online/offline state.
Once a build is queued, the plugin will start the instance and leave it running until after Jenkins marks the node offline.
This attempts to work around bugs found where the node has been started but Jenkins agent doesn't connect.